### PR TITLE
Feature/3.0.0 beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [3.0.0] - Unreleased
+## [3.0.0-beta.1] - 2026-06-15
 
 ### Changed
 
@@ -143,7 +143,7 @@ All notable changes to this project will be documented in this file.
 - `UrlBuilder` a class to build URLs through a template;
 - `RepositoryHttp` an implementation of `Repository` interface to fetch data through `HttpClient`.
 
-[3.0.0]: https://github.com/volverjs/data/compare/v2.0.5...v3.0.0
+[3.0.0-beta.1]: https://github.com/volverjs/data/compare/v2.0.5...v3.0.0-beta.1
 [2.0.5]: https://github.com/volverjs/data/compare/v2.0.4...v2.0.5
 [2.0.4]: https://github.com/volverjs/data/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/volverjs/data/compare/v2.0.2...v2.0.3

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The `HttpClient` class is a wrapper around [`ky`](https://github.com/sindresorhu
 import { HttpClient } from '@volverjs/data'
 
 const client = new HttpClient({
-    prefixUrl: 'https://my.api.com'
+    prefix: 'https://my.api.com'
 })
 const response = await client.get({
     template: ':endpoint/:action?/:id',
@@ -119,7 +119,7 @@ class User {
 }
 
 const client = new HttpClient({
-    prefixUrl: 'https://my.api.com'
+    prefix: 'https://my.api.com'
 })
 
 const repository = new RepositoryHttp<User>(client, 'users/:group?/:id?', {
@@ -152,7 +152,7 @@ import App from './App.vue'
 
 const app = createApp(App)
 const httpClientPlugin = createHttpClient({
-    prefixUrl: 'https://my.api.com'
+    prefix: 'https://my.api.com'
 })
 
 app.use(httpClientPlugin, {
@@ -180,7 +180,7 @@ import { createHttpClient, useHttpClient } from '@volverjs/data/vue'
 import { computed, ref } from 'vue'
 
 createHttpClient({
-    prefixUrl: 'https://my.api.com'
+    prefix: 'https://my.api.com'
 })
 
 const { client } = useHttpClient()
@@ -569,7 +569,7 @@ With `scope` parameter on `createHttpClient()` multiple `httpClient` instances c
 <script lang="ts" setup>
 import { createHttpClient } from '@volverjs/data/vue'
 
-createHttpClient({ scope: 'v2Api', prefixUrl: 'https://my.api.com/v2' })
+createHttpClient({ scope: 'v2Api', prefix: 'https://my.api.com/v2' })
 
 const { requestGet } = useHttpClient('v2Api')
 
@@ -592,7 +592,7 @@ The `global` `httpClient` instance cannot be removed.
 <script lang="ts" setup>
 import { createHttpClient, removeHttpClient } from '@volverjs/data/vue'
 
-createHttpClient({ scope: 'v2Api', prefixUrl: 'https://my.api.com/v2' })
+createHttpClient({ scope: 'v2Api', prefix: 'https://my.api.com/v2' })
 
 const { requestGet } = useHttpClient('v2Api')
 

--- a/docs/HttpClient.md
+++ b/docs/HttpClient.md
@@ -29,7 +29,7 @@ type HttpClientOptions = {
     headers?: HttpClientHeaders
     json?: unknown
     parseJson?: (text: string) => unknown // default: JSON.parse()
-    prefixUrl?: URL | string
+    prefix?: URL | string
     retry?: HttpClientRetryOptions | number
     timeout?: number | false // default: 10000
     hooks?: HttpClientHooks

--- a/docs/RepositoryHttp.md
+++ b/docs/RepositoryHttp.md
@@ -20,7 +20,7 @@ class User {
 }
 
 const client = new HttpClient({
-    prefixUrl: 'https://api.example.com'
+    prefix: 'https://api.example.com'
 })
 
 const repository = new RepositoryHttp<User>(client, 'users/:group?/:id?', {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     },
     "dependencies": {
         "abort-controller": "^3.0.0",
-        "ky": "^1.14.3",
+        "ky": "^2.0.2",
         "node-fetch": "^3.3.2",
         "qs": "^6.15.2",
         "web-streams-polyfill": "^4.3.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       ky:
-        specifier: ^1.14.3
-        version: 1.14.3
+        specifier: ^2.0.2
+        version: 2.0.2
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -1662,9 +1662,9 @@ packages:
     resolution: {integrity: sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==}
     engines: {node: '>=0.10.0'}
 
-  ky@1.14.3:
-    resolution: {integrity: sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==}
-    engines: {node: '>=18'}
+  ky@2.0.2:
+    resolution: {integrity: sha512-/GmXpo9F9W+f8n4Ivr2iH+7h7wL7jLbLKWkMlpflcCRb6kGjBfTlASEXaZ9qUgNTn4VgS0P2pwxxzQ4EM6Ulgg==}
+    engines: {node: '>=22'}
 
   lazy-cache@0.2.7:
     resolution: {integrity: sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==}
@@ -4289,7 +4289,7 @@ snapshots:
 
   kind-of@5.1.0: {}
 
-  ky@1.14.3: {}
+  ky@2.0.2: {}
 
   lazy-cache@0.2.7: {}
 

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -90,13 +90,13 @@ export { HTTPError, TimeoutError }
 export class HttpClient implements HttpClientInstance {
     private _client: KyInstance
     private _urlBuilder: UrlBuilderInstance
-    private _prefixUrl: string | URL | undefined
+    private _prefix: string | URL | undefined
 
     constructor(options: HttpClientInstanceOptions = {}) {
         const { client, urlBuilder, searchParams, ...clientOptions } = options
         this._client = client ?? ky.create(clientOptions)
         this._urlBuilder = urlBuilder ?? new UrlBuilder(searchParams)
-        this._prefixUrl = clientOptions.prefixUrl
+        this._prefix = clientOptions.prefix
     }
 
     public get = (
@@ -183,7 +183,7 @@ export class HttpClient implements HttpClientInstance {
     public extend = (options: HttpClientOptions = {}) => {
         const { searchParams, ...clientOptions } = options
         this._client = this._client.extend(clientOptions)
-        this._prefixUrl = clientOptions.prefixUrl ?? this._prefixUrl
+        this._prefix = clientOptions.prefix ?? this._prefix
         this._urlBuilder.extend(searchParams ?? {})
     }
 
@@ -216,7 +216,7 @@ export class HttpClient implements HttpClientInstance {
     ): HttpClientInput {
         const toReturn = HttpClient.buildUrl(url, options, this._urlBuilder)
         if (
-            this._prefixUrl
+            this._prefix
             && typeof toReturn === 'string'
             && toReturn?.startsWith('/')
         ) {

--- a/src/RepositoryHttp.ts
+++ b/src/RepositoryHttp.ts
@@ -30,7 +30,7 @@ export type RepositoryHttpOptions<TRequest, TResponse = TRequest> = {
      * @default undefined
      * @example
      * ```typescript
-     * addHttpClient('v2', { prefixUrl: 'https://myapi.com/v2' })
+     * addHttpClient('v2', { prefix: 'https://myapi.com/v2' })
      * const { read } = useRepositoryHttp<{ id: string }>('users/?:id', { httpClientScope: 'v2' })
      * read({ id: 1 })
      * //=> GET https://myapi.com/v2/?id=1
@@ -42,7 +42,7 @@ export type RepositoryHttpOptions<TRequest, TResponse = TRequest> = {
      * @default undefined
      * @example
      * ```typescript
-     * const repository = new RepositoryHttp(client, 'users/?:id', { httpClientOptions: { prefixUrl: 'https://example.com' } })
+     * const repository = new RepositoryHttp(client, 'users/?:id', { httpClientOptions: { prefix: 'https://example.com' } })
      * repository.read({ id: 1 })
      * //=> GET https://example.com/?id=1
      * ```

--- a/src/RepositoryHttp.ts
+++ b/src/RepositoryHttp.ts
@@ -184,7 +184,7 @@ implements Repository<TRequest, TResponse> {
             this._httpClientOptions = options.httpClientOptions
         }
         if (options?.class && !options?.responseAdapter) {
-            const OptionsClass = options.class as new (...args: any[]) => TResponse
+            const OptionsClass = options.class
             this._responseAdapter = (raw) => {
                 return Array.isArray(raw)
                     ? raw.map(rawItem => new OptionsClass(rawItem))

--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -84,7 +84,7 @@ class HttpClientPlugin extends HttpClient {
  *
  * const app = createApp(App)
  * const client = createHttpClient({
- *  prefixUrl: 'https://my.api.com'
+ *  prefix: 'https://my.api.com'
  * })
  * app.use(client)
  * ```
@@ -97,7 +97,7 @@ class HttpClientPlugin extends HttpClient {
  *
  * const app = createApp(App)
  * const client = createHttpClient({
- *  prefixUrl: 'https://my.api-v2.com',
+ *  prefix: 'https://my.api-v2.com',
  *  scope: 'apiV2'
  * })
  *

--- a/test/httpClient.test.ts
+++ b/test/httpClient.test.ts
@@ -59,7 +59,7 @@ describe('httpClient', () => {
     it('should make a GET request with template and query parameters and prefix url', async () => {
         fetchMock.mockResponseOnce(JSON.stringify([{ id: '12345' }]))
         const client = new HttpClient({
-            prefixUrl: 'https://myapi.com/v1',
+            prefix: 'https://myapi.com/v1',
         })
         const data = (await client
             .get({
@@ -79,7 +79,7 @@ describe('httpClient', () => {
     it('should make a GET request with error', async () => {
         fetchMock.mockResponseOnce(() => ({ status: 404 }))
         const client = new HttpClient({
-            prefixUrl: 'https://myapi.com/v1',
+            prefix: 'https://myapi.com/v1',
         })
         try {
             await client
@@ -101,7 +101,7 @@ describe('httpClient', () => {
     it('should abort a GET request', async () => {
         fetchMock.mockResponseOnce(JSON.stringify([{ id: '12345' }]))
         const client = new HttpClient({
-            prefixUrl: 'https://myapi.com/v1',
+            prefix: 'https://myapi.com/v1',
         })
         const { responsePromise, abort, signal } = client.request(
             'get',

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -13,7 +13,7 @@ describe('repositoryHttp', () => {
     it('should read', async () => {
         fetchMock.mockResponseOnce(JSON.stringify([{ id: '12345' }]))
         const client = new HttpClient({
-            prefixUrl: 'https://myapi.com/v1',
+            prefix: 'https://myapi.com/v1',
         })
         const repository = new RepositoryHttp<{ id: string }>(client, ':type')
         const { responsePromise } = repository.read({
@@ -31,7 +31,7 @@ describe('repositoryHttp', () => {
     })
     it('should stop a read request', async () => {
         const client = new HttpClient({
-            prefixUrl: 'https://myapi.com/v1',
+            prefix: 'https://myapi.com/v1',
         })
         const repository = new RepositoryHttp(client, ':type?')
         const { responsePromise, abort } = repository.read({})
@@ -43,7 +43,7 @@ describe('repositoryHttp', () => {
     it('should merge 2 equals read requests', async () => {
         fetchMock.mockResponseOnce(JSON.stringify([{ id: '12345' }]))
         const client = new HttpClient({
-            prefixUrl: 'https://myapi.com/v1',
+            prefix: 'https://myapi.com/v1',
         })
         const repository = new RepositoryHttp<{ id: string }>(client, ':type')
         const { responsePromise: responsePromise1 } = repository.read({
@@ -69,7 +69,7 @@ describe('repositoryHttp', () => {
     it('should merge 2 equals read request, first aborted', async () => {
         fetchMock.mockResponseOnce(JSON.stringify([{ id: '12345' }]))
         const client = new HttpClient({
-            prefixUrl: 'https://myapi.com/v1',
+            prefix: 'https://myapi.com/v1',
         })
         const repository = new RepositoryHttp<{ id: string }>(client, ':type')
         const { responsePromise: responsePromise1, abort } = repository.read({
@@ -95,7 +95,7 @@ describe('repositoryHttp', () => {
     it('should merge 2 equals read request, second aborted', async () => {
         fetchMock.mockResponseOnce(JSON.stringify([{ id: '12345' }]))
         const client = new HttpClient({
-            prefixUrl: 'https://myapi.com/v1',
+            prefix: 'https://myapi.com/v1',
         })
         const repository = new RepositoryHttp<{ id: string }>(client, ':type')
         const { responsePromise: responsePromise1 } = repository.read({
@@ -127,7 +127,7 @@ describe('repositoryHttp', () => {
             },
         })
         const client = new HttpClient({
-            prefixUrl: 'https://myapi.com/v1',
+            prefix: 'https://myapi.com/v1',
         })
         const repository = new RepositoryHttp<{ id: string }>(client, ':type')
         const { responsePromise } = repository.read({ type: 'alpha' })

--- a/test/vueHttpClient.test.ts
+++ b/test/vueHttpClient.test.ts
@@ -75,7 +75,7 @@ describe('vue useHttpClient', () => {
     it('should make a GET request with template and query parameters and prefix url', async () => {
         fetchMock.mockResponseOnce(JSON.stringify([{ id: '12345' }]))
         createHttpClient({
-            prefixUrl: 'https://myapi.com/v1',
+            prefix: 'https://myapi.com/v1',
             scope: 'myApi',
         })
         const { requestGet } = useHttpClient('myApi')
@@ -99,7 +99,7 @@ describe('vue useHttpClient', () => {
     it('should make a GET request with error', async () => {
         fetchMock.mockResponseOnce(() => ({ status: 404 }))
         createHttpClient({
-            prefixUrl: 'https://myapi.com/v2',
+            prefix: 'https://myapi.com/v2',
             scope: 'myApi2',
         })
         const { requestGet } = useHttpClient('myApi2')
@@ -122,7 +122,7 @@ describe('vue useHttpClient', () => {
     it('should abort a GET request', async () => {
         fetchMock.mockResponseOnce(JSON.stringify([{ id: '12345' }]))
         createHttpClient({
-            prefixUrl: 'https://myapi.com/v3',
+            prefix: 'https://myapi.com/v3',
             scope: 'myApi3',
         })
         const { request } = useHttpClient('myApi3')
@@ -140,7 +140,7 @@ describe('vue useHttpClient', () => {
         fetchMock.mockResponseOnce(JSON.stringify([{ id: '12345' }]))
 
         createHttpClient({
-            prefixUrl: 'https://myapi.com/v4',
+            prefix: 'https://myapi.com/v4',
             scope: 'myApi4',
         })
 
@@ -156,7 +156,7 @@ describe('vue useHttpClient', () => {
         fetchMock.mockResponseOnce(JSON.stringify([{ id: '12345' }]))
 
         createHttpClient({
-            prefixUrl: 'https://myapi.com/v5',
+            prefix: 'https://myapi.com/v5',
             scope: 'myApi5',
         })
 
@@ -173,7 +173,7 @@ describe('vue useHttpClient', () => {
         fetchMock.mockResponseOnce(JSON.stringify([{ id: '12345' }]))
 
         createHttpClient({
-            prefixUrl: 'https://myapi.com/v6',
+            prefix: 'https://myapi.com/v6',
             scope: 'myApi6',
         })
 
@@ -187,7 +187,7 @@ describe('vue useHttpClient', () => {
 
         try {
             createHttpClient({
-                prefixUrl: 'https://myapi.com/v6',
+                prefix: 'https://myapi.com/v6',
                 scope: 'myApi6',
             })
         }
@@ -202,7 +202,7 @@ describe('vue useHttpClient', () => {
         fetchMock.mockResponseOnce(JSON.stringify([{ id: '12345' }]))
 
         createHttpClient({
-            prefixUrl: 'https://myapi.com/v7',
+            prefix: 'https://myapi.com/v7',
             scope: 'myApi7',
         })
 

--- a/test/vueRepository.test.ts
+++ b/test/vueRepository.test.ts
@@ -9,7 +9,7 @@ const fetchMock = createFetchMock(vi)
 
 // Install a plugin onto VueWrapper
 const httpClient = createHttpClient({
-    prefixUrl: 'https://myapi.com/v1',
+    prefix: 'https://myapi.com/v1',
 })
 
 const component = {
@@ -30,7 +30,7 @@ const componentHttpClientV2 = {
     template: '<div />',
     setup: () => {
         createHttpClient({
-            prefixUrl: 'https://myapi.com/v2',
+            prefix: 'https://myapi.com/v2',
             scope: 'v2',
         })
         const { read } = useRepositoryHttp<{ id: string }>(':type', {


### PR DESCRIPTION
### Changed

- **BREAKING:** upgraded `ky` to `2.x`, which renames the `HttpClient` option `prefixUrl` to `prefix`. Update every `new HttpClient({ prefixUrl })`, `createHttpClient({ prefixUrl })` and `httpClientOptions: { prefixUrl }` usage to `prefix`.